### PR TITLE
Turn codeql back on for java and c-cpp

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -99,7 +99,8 @@ jobs:
         if test -x "$(which gradle)" && test -w . && test -w "${HOME}"; then \
           if test -w "${HOME}/work/ghidra/ghidra/.gradle" || (test -n "${GRADLE_HOME}" && test -d "${GRADLE_HOME}" && test -w "${GRADLE_HOME}"); then \
             echo "initializing gradle ($(which gradle))..."; \
-            gradle --info -I gradle/support/fetchDependencies.gradle init || (if test -x ./gradlew; then ./gradlew --debug -I gradle/support/fetchDependencies.gradle init; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || sudo gradle -I gradle/support/fetchDependencies.gradle init || ls "gradle*" || pwd; \
+            gradle --quiet --configuration-cache-problems warn --continue wrapper || find . -name '*/gradlew' -print || echo "whoami? $(whoami)"; \
+            gradle --info -I gradle/support/fetchDependencies.gradle init || (if test -x ./gradlew; then ./gradlew --debug -I gradle/support/fetchDependencies.gradle init; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || sudo gradle --quiet --configuration-cache-problems warn --continue -I gradle/support/fetchDependencies.gradle init || ls "gradle*" || pwd; \
             gradle prepdev eclipse buildNatives || (if test -x ./gradlew; then ./gradlew prepdev eclipse buildNatives; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || find . -name '*.gradle' -print; \
           else \
             echo "Skipping gradle initialization due to missing or unwritable gradle locations"; \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -89,13 +89,13 @@ jobs:
       if: matrix.language == 'c-cpp' || matrix.language == 'java-kotlin'
       run: |
         sudo apt-get -qq update
-        sudo apt-get -q install gradle make gcc libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java binutils
+        sudo apt-get -q install gradle dh-make g++ libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java binutils default-jre libasprintf-dev libgettextpo-dev ecj maven-debian-helper gdb
         env | uniq | sort | uniq
         # shellcheck disable=SC2235
         if test -x "$(which gradle)" && test -w . && test -w "${HOME}"; then \
           if test -w "${HOME}/work/ghidra/ghidra/.gradle" || (test -n "${GRADLE_HOME}" && test -d "${GRADLE_HOME}" && test -w "${GRADLE_HOME}"); then \
             echo "initializing gradle ($(which gradle))..."; \
-            gradle --info -I gradle/support/fetchDependencies.gradle init || (if test -x ./gradlew; then ./gradlew --debug -I gradle/support/fetchDependencies.gradle init; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || sudo gradle --stacktrace -I gradle/support/fetchDependencies.gradle init || ls "gradle*"; \
+            gradle --info -I gradle/support/fetchDependencies.gradle init || (if test -x ./gradlew; then ./gradlew --debug -I gradle/support/fetchDependencies.gradle init; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || sudo gradle -I gradle/support/fetchDependencies.gradle init || ls "gradle*" || pwd; \
             gradle prepdev eclipse buildNatives || (if test -x ./gradlew; then ./gradlew prepdev eclipse buildNatives; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || find . -name '*.gradle' -print; \
           else \
             echo "Skipping gradle initialization due to missing or unwritable gradle locations"; \
@@ -142,7 +142,7 @@ jobs:
         for javafile in $(find . -name '*.java' -type f); do \
           echo "One last attempt at compiling ${javafile}..."; \
           javac "${javafile}" || stat "${javafile}"; \
-        done #
+        done
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript-typescript', 'python' ]
+        language: [ 'c-cpp', 'java-kotlin', 'javascript-typescript', 'python' ]
         # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
         # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,8 +39,8 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    runs-on: ${{ (matrix.language == 'c-cpp' && 'windows-latest') || 'ubuntu-latest' }}
+    timeout-minutes: 420
     permissions:
       actions: read
       contents: read
@@ -86,17 +86,21 @@ jobs:
         # queries: security-extended,security-and-quality
 
     - name: Additional dependencies
-      if: matrix.language == 'c-cpp' || matrix.language == 'java-kotlin'
+      if: matrix.language == 'java-kotlin'
       run: |
         sudo apt-get -qq update
-        sudo apt-get -qq install gradle make gcc
+        sudo apt-get -qq install gradle make gcc libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java
         env | uniq | sort | uniq
         if test -x "$(which gradle)" && test -w . && test -w "${HOME}"; then \
-          if test -w "${HOME}work/ghidra/ghidra/.gradle/"; then \
+          if test -w "${HOME}/work/ghidra/ghidra/.gradle/"; then \
             echo "initializing gradle ($(which gradle))..."; \
             gradle --debug -I gradle/support/fetchDependencies.gradle init; \
             gradle prepdev eclipse buildNatives; \
+          else \
+            echo "Skipping gradle initialization"; \
           fi; \
+        else \
+          echo "Conditions are wrong for initializing gradle"; \
         fi
 
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,11 +85,15 @@ jobs:
         # https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
+    - name: Setup Gradle
+      if: matrix.language == 'java-kotlin'
+      uses: gradle/gradle-build-action@v2
+
     - name: Additional dependencies
       if: matrix.language == 'c-cpp' || matrix.language == 'java-kotlin'
       run: |
         sudo apt-get -qq update
-        sudo apt-get -q install gradle dh-make g++ libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java binutils default-jre libasprintf-dev libgettextpo-dev ecj maven-debian-helper gdb
+        sudo apt-get -q install gradle dh-make libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java binutils default-jre libasprintf-dev libgettextpo-dev ecj maven-debian-helper gdb gdbserver android-debian-helper mingw-w64 wine wine64
         env | uniq | sort | uniq
         # shellcheck disable=SC2235
         if test -x "$(which gradle)" && test -w . && test -w "${HOME}"; then \
@@ -107,7 +111,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      if: matrix.language != 'c-cpp' && matrix.language != 'java-kotlin'
+      if: matrix.language != 'c-cpp' # && matrix.language != 'java-kotlin'
       uses: github/codeql-action/autobuild@v3
 
     - name: Manual build (C and C++)
@@ -139,9 +143,13 @@ jobs:
       if: matrix.language == 'java-kotlin'
       run: |
         # shellcheck disable=SC2044
-        for javafile in $(find . -name '*.java' -type f); do \
-          echo "One last attempt at compiling ${javafile}..."; \
-          javac "${javafile}" || stat "${javafile}"; \
+        for deptharg in $(seq 5 16); do \
+          echo "operating at depth ${deptharg}..."; \
+          for javafile in $(find . -name '*.java' -type f -depth "${deptharg}"); do \
+            echo "One last attempt at compiling ${javafile} (at depth ${deptharg})..."; \
+            javac -nowarn -Xdiags:compact -Xmaxerrs 1 "${javafile}" || stat "${javafile}"; \
+          done; \
+          date; \
         done
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -89,14 +89,14 @@ jobs:
       if: matrix.language == 'c-cpp' || matrix.language == 'java-kotlin'
       run: |
         sudo apt-get -qq update
-        sudo apt-get -qq install gradle make gcc libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java
+        sudo apt-get -q install gradle make gcc libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java binutils
         env | uniq | sort | uniq
         # shellcheck disable=SC2235
         if test -x "$(which gradle)" && test -w . && test -w "${HOME}"; then \
           if test -w "${HOME}/work/ghidra/ghidra/.gradle" || (test -n "${GRADLE_HOME}" && test -d "${GRADLE_HOME}" && test -w "${GRADLE_HOME}"); then \
             echo "initializing gradle ($(which gradle))..."; \
-            gradle --info -I gradle/support/fetchDependencies.gradle init || (if test -x ./gradlew; then ./gradlew --debug -I gradle/support/fetchDependencies.gradle init; else echo "missing gradle wrapper"; fi) || sudo gradle --stacktrace -I gradle/support/fetchDependencies.gradle init || ls "gradle*"; \
-            gradle prepdev eclipse buildNatives || (if test -x ./gradlew; then ./gradlew prepdev eclipse buildNatives; else echo "missing gradle wrapper"; fi) || find . -name '*.gradle' -print; \
+            gradle --info -I gradle/support/fetchDependencies.gradle init || (if test -x ./gradlew; then ./gradlew --debug -I gradle/support/fetchDependencies.gradle init; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || sudo gradle --stacktrace -I gradle/support/fetchDependencies.gradle init || ls "gradle*"; \
+            gradle prepdev eclipse buildNatives || (if test -x ./gradlew; then ./gradlew prepdev eclipse buildNatives; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || find . -name '*.gradle' -print; \
           else \
             echo "Skipping gradle initialization due to missing or unwritable gradle locations"; \
           fi; \
@@ -107,10 +107,10 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      if: matrix.language != 'c-cpp'
+      if: matrix.language != 'c-cpp' && matrix.language != 'java-kotlin'
       uses: github/codeql-action/autobuild@v3
 
-    - name: Manual build
+    - name: Manual build (C and C++)
       if: matrix.language == 'c-cpp'
       run: |
         # shellcheck disable=SC2001,SC2044
@@ -132,8 +132,17 @@ jobs:
         # shellcheck disable=SC2044
         for cppfile in $(find . -name '*.cpp' -type f); do \
           echo "One last attempt at compiling ${cppfile}..."; \
-          g++ -c "${cppfile}" || g++ -w -c -I. "${cppfile}" || g++ -w -Wno-error -c -I. -I.. "${cppfile}" || stat "${cppfile}"; \
+          g++ -Wfatal-errors -c "${cppfile}" || g++ -w -Wfatal-errors -c -I. "${cppfile}" || g++ -w -Wno-error -Wfatal-errors -fpermissive -c -I. -I.. "${cppfile}" || stat "${cppfile}"; \
         done
+
+    - name: Manual build (Java)
+      if: matrix.language == 'java-kotlin'
+      run: |
+        # shellcheck disable=SC2044
+        for javafile in $(find . -name '*.java' -type f); do \
+          echo "One last attempt at compiling ${javafile}..."; \
+          javac "${javafile}" || stat "${javafile}"; \
+        done #
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -95,8 +95,8 @@ jobs:
         if test -x "$(which gradle)" && test -w . && test -w "${HOME}"; then \
           if test -w "${HOME}/work/ghidra/ghidra/.gradle" || (test -n "${GRADLE_HOME}" && test -d "${GRADLE_HOME}" && test -w "${GRADLE_HOME}"); then \
             echo "initializing gradle ($(which gradle))..."; \
-            gradle --debug -I gradle/support/fetchDependencies.gradle init || ./gradlew --debug -I gradle/support/fetchDependencies.gradle init || sudo gradle --stacktrace -I gradle/support/fetchDependencies.gradle init; \
-            gradle prepdev eclipse buildNatives || ./gradlew prepdev eclipse buildNatives; \
+            gradle --info -I gradle/support/fetchDependencies.gradle init || (if test -x ./gradlew; then ./gradlew --debug -I gradle/support/fetchDependencies.gradle init; else echo "missing gradle wrapper"; fi) || sudo gradle --stacktrace -I gradle/support/fetchDependencies.gradle init || ls "gradle*"; \
+            gradle prepdev eclipse buildNatives || (if test -x ./gradlew; then ./gradlew prepdev eclipse buildNatives; else echo "missing gradle wrapper"; fi) || find . -name '*.gradle' -print; \
           else \
             echo "Skipping gradle initialization due to missing or unwritable gradle locations"; \
           fi; \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -93,7 +93,7 @@ jobs:
       if: matrix.language == 'c-cpp' || matrix.language == 'java-kotlin'
       run: |
         sudo apt-get -qq update
-        sudo apt-get -q install gradle dh-make libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java binutils default-jre libasprintf-dev libgettextpo-dev ecj maven-debian-helper gdb gdbserver android-debian-helper mingw-w64 wine wine64
+        sudo apt-get -q install gradle dh-make libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java binutils default-jre libasprintf-dev libgettextpo-dev ecj maven-debian-helper gdb gdbserver mingw-w64 wine wine64
         env | uniq | sort | uniq
         # shellcheck disable=SC2235
         if test -x "$(which gradle)" && test -w . && test -w "${HOME}"; then \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ on:
       - master
       - patch
       - stable
+      - additional_codeql_langs
       - dependabot/*
   pull_request:
     # The branches below must be a subset of the branches above
@@ -25,6 +26,7 @@ on:
       - master
       - patch
       - stable
+      - additional_codeql_langs
       - dependabot/*
   schedule:
     - cron: '43 20 * * 5'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -99,8 +99,8 @@ jobs:
         if test -x "$(which gradle)" && test -w . && test -w "${HOME}"; then \
           if test -w "${HOME}/work/ghidra/ghidra/.gradle" || (test -n "${GRADLE_HOME}" && test -d "${GRADLE_HOME}" && test -w "${GRADLE_HOME}"); then \
             echo "initializing gradle ($(which gradle))..."; \
-            gradle --quiet --configuration-cache-problems warn --continue wrapper || find . -name '*/gradlew' -print || echo "whoami? $(whoami)"; \
-            gradle --info -I gradle/support/fetchDependencies.gradle init || (if test -x ./gradlew; then ./gradlew --debug -I gradle/support/fetchDependencies.gradle init; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || sudo gradle --quiet --configuration-cache-problems warn --continue -I gradle/support/fetchDependencies.gradle init || ls "gradle*" || pwd; \
+            gradle --quiet --continue wrapper || find . -name '*/gradlew' -print || echo "whoami? $(whoami)"; \
+            gradle --info -I gradle/support/fetchDependencies.gradle init || (if test -x ./gradlew; then ./gradlew --debug -I gradle/support/fetchDependencies.gradle init; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || sudo gradle --quiet --continue -I gradle/support/fetchDependencies.gradle init || ls "gradle*" || pwd; \
             gradle prepdev eclipse buildNatives || (if test -x ./gradlew; then ./gradlew prepdev eclipse buildNatives; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || find . -name '*.gradle' -print; \
           else \
             echo "Skipping gradle initialization due to missing or unwritable gradle locations"; \
@@ -132,12 +132,12 @@ jobs:
         # shellcheck disable=SC2044
         for ccfile in $(find . -name '*.cc' -type f); do \
           echo "One last attempt at compiling ${ccfile}..."; \
-          g++ -c "${ccfile}" || g++ -w -c -I. "${ccfile}" || g++ -w -Wno-error -c -I. -I.. "${ccfile}" || stat "${ccfile}"; \
+          g++ -c "${ccfile}" || g++ -w -c -I. "${ccfile}" || g++ -w -Wno-error -c -I. -I.. "${ccfile}" || stat -t "${ccfile}"; \
         done
         # shellcheck disable=SC2044
         for cppfile in $(find . -name '*.cpp' -type f); do \
           echo "One last attempt at compiling ${cppfile}..."; \
-          g++ -Wfatal-errors -c "${cppfile}" || g++ -w -Wfatal-errors -c -I. "${cppfile}" || g++ -w -Wno-error -Wfatal-errors -fpermissive -c -I. -I.. "${cppfile}" || stat "${cppfile}"; \
+          g++ -Wno-write-strings -Wfatal-errors -c "${cppfile}" || g++ -w -Wfatal-errors -c -I. "${cppfile}" || g++ -w -Wno-error -Wfatal-errors -fpermissive -c -I. -I.. "${cppfile}" || stat -t "${cppfile}"; \
         done
 
     - name: Manual build (Java)
@@ -148,7 +148,7 @@ jobs:
           echo "operating at depth ${deptharg}..."; \
           for javafile in $(find . -name '*.java' -type f -depth "${deptharg}"); do \
             echo "One last attempt at compiling ${javafile} (at depth ${deptharg})..."; \
-            javac -nowarn -Xdiags:compact -Xmaxerrs 1 "${javafile}" || stat "${javafile}"; \
+            javac -nowarn -Xdiags:compact -Xmaxerrs 1 "${javafile}" || stat -t "${javafile}"; \
           done; \
           date; \
         done

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'c-cpp' && 'windows-latest') || 'ubuntu-latest' }}
+    runs-on: 'ubuntu-latest'
     timeout-minutes: 420
     permissions:
       actions: read
@@ -86,18 +86,19 @@ jobs:
         # queries: security-extended,security-and-quality
 
     - name: Additional dependencies
-      if: matrix.language == 'java-kotlin'
+      if: matrix.language == 'c-cpp' || matrix.language == 'java-kotlin'
       run: |
         sudo apt-get -qq update
         sudo apt-get -qq install gradle make gcc libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java
         env | uniq | sort | uniq
+        # shellcheck disable=SC2235
         if test -x "$(which gradle)" && test -w . && test -w "${HOME}"; then \
-          if test -w "${HOME}/work/ghidra/ghidra/.gradle/"; then \
+          if test -w "${HOME}/work/ghidra/ghidra/.gradle" || (test -n "${GRADLE_HOME}" && test -d "${GRADLE_HOME}" && test -w "${GRADLE_HOME}"); then \
             echo "initializing gradle ($(which gradle))..."; \
             gradle --debug -I gradle/support/fetchDependencies.gradle init; \
             gradle prepdev eclipse buildNatives; \
           else \
-            echo "Skipping gradle initialization"; \
+            echo "Skipping gradle initialization due to missing or unwritable gradle locations"; \
           fi; \
         else \
           echo "Conditions are wrong for initializing gradle"; \
@@ -106,18 +107,33 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
+      if: matrix.language != 'c-cpp'
       uses: github/codeql-action/autobuild@v3
 
-    # Command-line programs to run using the OS shell.
-    # See:
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
+    - name: Manual build
+      if: matrix.language == 'c-cpp'
+      run: |
+        # shellcheck disable=SC2001,SC2044
+        for cfile in $(find . -name '*.c' -type f); do \
+          cobjfile="$(echo "${cfile}" | sed "s/\.c/.o/g")"; \
+          if test ! -e "${cobjfile}"; then \
+            echo "gcc -c -w -Wno-error \"${cfile}\""; \
+            gcc -c -w -Wno-error "${cfile}" || stat -t "${cfile}" || echo "cfile is ${cfile}"; \
+          else \
+            echo "object file ${cobjfile} already exists for ${cfile}."; \
+            cp -v "${cobjfile}" "$(dirname "${cfile}")" || cp -v "${cobjfile}" . || cp -v "${cobjfile}" .. || (if test -d /tmp && test -w /tmp; then cp -v "${cobjfile}" /tmp; fi) || stat -t "${cobjfile}"; \
+          fi; \
+        done
+        # shellcheck disable=SC2044
+        for ccfile in $(find . -name '*.cc' -type f); do \
+          echo "One last attempt at compiling ${ccfile}..."; \
+          g++ -c "${ccfile}" || g++ -w -c -I. "${ccfile}" || g++ -w -Wno-error -c -I. -I.. "${ccfile}" || stat "${ccfile}"; \
+        done
+        # shellcheck disable=SC2044
+        for cppfile in $(find . -name '*.cpp' -type f); do \
+          echo "One last attempt at compiling ${cppfile}..."; \
+          g++ -c "${cppfile}" || g++ -w -c -I. "${cppfile}" || g++ -w -Wno-error -c -I. -I.. "${cppfile}" || stat "${cppfile}"; \
+        done
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -101,6 +101,7 @@ jobs:
             echo "initializing gradle ($(which gradle))..."; \
             gradle --quiet --continue wrapper || find . -name '*/gradlew' -print || echo "whoami? $(whoami)"; \
             gradle --info -I gradle/support/fetchDependencies.gradle init || (if test -x ./gradlew; then ./gradlew --debug -I gradle/support/fetchDependencies.gradle init; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || sudo gradle --quiet --continue -I gradle/support/fetchDependencies.gradle init || ls "gradle*" || pwd; \
+            echo "one more gradle setup step..."; \
             gradle --quiet prepdev eclipse buildNatives || (if test -x ./gradlew; then ./gradlew prepdev eclipse buildNatives; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || find . -name '*.gradle' -print; \
           else \
             echo "Skipping gradle initialization due to missing or unwritable gradle locations"; \
@@ -122,8 +123,8 @@ jobs:
         for cfile in $(find . -name '*.c' -type f); do \
           cobjfile="$(echo "${cfile}" | sed "s/\.c/.o/g")"; \
           if test ! -e "${cobjfile}"; then \
-            echo "gcc -c -w -Wno-error \"${cfile}\""; \
-            gcc -c -w -Wno-error "${cfile}" || stat -t "${cfile}" || echo "cfile is ${cfile}"; \
+            echo "gcc -c -w -Wno-error -I. \"${cfile}\""; \
+            gcc -c -w -Wno-error -I. -I"$(dirname "${cfile}")" -iquote . -iquote "$(dirname "${cfile}")" "${cfile}" || stat -t "${cfile}" || echo "cfile is ${cfile}"; \
           else \
             echo "object file ${cobjfile} already exists for ${cfile}."; \
             cp -v "${cobjfile}" "$(dirname "${cfile}")" || cp -v "${cobjfile}" . || cp -v "${cobjfile}" .. || (if test -d /tmp && test -w /tmp; then cp -v "${cobjfile}" /tmp; fi) || stat -t "${cobjfile}"; \
@@ -144,14 +145,10 @@ jobs:
       if: matrix.language == 'java-kotlin'
       run: |
         # shellcheck disable=SC2044
-        for deptharg in $(seq 5 16); do \
-          echo "operating at depth ${deptharg}..."; \
-          for javafile in $(find . -name '*.java' -type f -depth "${deptharg}"); do \
-            echo "One last attempt at compiling ${javafile} (at depth ${deptharg})..."; \
-            javac -nowarn -Xdiags:compact -Xmaxerrs 1 "${javafile}" || stat -t "${javafile}"; \
-          done; \
-          date; \
-        done
+        for javafile in $(find . -maxdepth 5 -name '*.java' -type f); do \
+          echo "One last attempt at compiling ${javafile}..."; \
+          javac -nowarn -Xdiags:compact -Xmaxerrs 1 "${javafile}" || stat -t "${javafile}"; \
+        done; \
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -93,7 +93,7 @@ jobs:
       if: matrix.language == 'c-cpp' || matrix.language == 'java-kotlin'
       run: |
         sudo apt-get -qq update
-        sudo apt-get -q install gradle dh-make libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java binutils binutils-dev binutils-multiarch-dev default-jre libasprintf-dev libgettextpo-dev ecj maven-debian-helper gdb gdbserver mingw-w64 wine wine64 libiberty-dev
+        sudo apt-get -qq install gradle dh-make libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java binutils binutils-dev binutils-multiarch-dev default-jre libasprintf-dev libgettextpo-dev ecj maven-debian-helper gdb gdbserver mingw-w64 wine wine64 libiberty-dev
         env | uniq | sort | uniq
         # shellcheck disable=SC2235
         if test -x "$(which gradle)" && test -w . && test -w "${HOME}"; then \
@@ -123,7 +123,7 @@ jobs:
         for cfile in $(find . -name '*.c' -type f); do \
           cobjfile="$(echo "${cfile}" | sed "s/\.c/.o/g")"; \
           if test ! -e "${cobjfile}"; then \
-            echo "gcc -c -w -Wno-error -I. \"${cfile}\""; \
+            echo "gcc -c -w -Wno-error -I. -iquote . \"${cfile}\""; \
             gcc -c -w -Wno-error -I. -I"$(dirname "${cfile}")" -iquote . -iquote "$(dirname "${cfile}")" "${cfile}" || stat -t "${cfile}" || echo "cfile is ${cfile}"; \
           else \
             echo "object file ${cobjfile} already exists for ${cfile}."; \
@@ -133,22 +133,23 @@ jobs:
         # shellcheck disable=SC2044
         for ccfile in $(find . -name '*.cc' -type f); do \
           echo "One last attempt at compiling ${ccfile}..."; \
-          g++ -c "${ccfile}" || g++ -w -c -I. "${ccfile}" || g++ -w -Wno-error -c -I. -I.. "${ccfile}" || stat -t "${ccfile}"; \
+          g++ -c "${ccfile}" || g++ -w -c -I. -iquote . "${ccfile}" || g++ -w -Wno-error -c -I. -iquote . -I.. -iquote .. -I"$(dirname "${cfile}")" -iquote "$(dirname "${cfile}")" "${ccfile}" || stat -t "${ccfile}"; \
         done
         # shellcheck disable=SC2044
         for cppfile in $(find . -name '*.cpp' -type f); do \
           echo "One last attempt at compiling ${cppfile}..."; \
-          g++ -Wno-write-strings -Wfatal-errors -c "${cppfile}" || g++ -w -Wfatal-errors -c -I. "${cppfile}" || g++ -w -Wno-error -Wfatal-errors -fpermissive -c -I. -I.. "${cppfile}" || stat -t "${cppfile}"; \
+          g++ -Wno-write-strings -Wfatal-errors -c "${cppfile}" || g++ -w -Wfatal-errors -c -I. -iquote . "${cppfile}" || g++ -w -Wno-error -Wfatal-errors -fpermissive -c -I. -iquote . -I.. -iquote .. -I"$(dirname "${cfile}")" -iquote "$(dirname "${cfile}")" "${cppfile}" || stat -t "${cppfile}"; \
         done
 
     - name: Manual build (Java)
       if: matrix.language == 'java-kotlin'
       run: |
         # shellcheck disable=SC2044
-        for javafile in $(find . -maxdepth 5 -name '*.java' -type f); do \
+        for javafile in $(find . -maxdepth 6 -name '*.java' -type f); do \
           echo "One last attempt at compiling ${javafile}..."; \
           javac -nowarn -Xdiags:compact -Xmaxerrs 1 "${javafile}" || stat -t "${javafile}"; \
         done; \
+        date
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -95,8 +95,8 @@ jobs:
         if test -x "$(which gradle)" && test -w . && test -w "${HOME}"; then \
           if test -w "${HOME}/work/ghidra/ghidra/.gradle" || (test -n "${GRADLE_HOME}" && test -d "${GRADLE_HOME}" && test -w "${GRADLE_HOME}"); then \
             echo "initializing gradle ($(which gradle))..."; \
-            gradle --debug -I gradle/support/fetchDependencies.gradle init; \
-            gradle prepdev eclipse buildNatives; \
+            gradle --debug -I gradle/support/fetchDependencies.gradle init || ./gradlew --debug -I gradle/support/fetchDependencies.gradle init || sudo gradle --stacktrace -I gradle/support/fetchDependencies.gradle init; \
+            gradle prepdev eclipse buildNatives || ./gradlew prepdev eclipse buildNatives; \
           else \
             echo "Skipping gradle initialization due to missing or unwritable gradle locations"; \
           fi; \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -93,7 +93,7 @@ jobs:
       if: matrix.language == 'c-cpp' || matrix.language == 'java-kotlin'
       run: |
         sudo apt-get -qq update
-        sudo apt-get -q install gradle dh-make libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java binutils default-jre libasprintf-dev libgettextpo-dev ecj maven-debian-helper gdb gdbserver mingw-w64 wine wine64
+        sudo apt-get -q install gradle dh-make libgradle-core-java libgradle-plugins-java gradle-propdeps-plugin gradle-debian-helper libgradle-jflex-plugin-java gradle-plugin-protobuf gradle-ice-builder-plugin libgradle-android-plugin-java gradle-apt-plugin liblightvalue-gradle-plugin-java binutils binutils-dev binutils-multiarch-dev default-jre libasprintf-dev libgettextpo-dev ecj maven-debian-helper gdb gdbserver mingw-w64 wine wine64 libiberty-dev
         env | uniq | sort | uniq
         # shellcheck disable=SC2235
         if test -x "$(which gradle)" && test -w . && test -w "${HOME}"; then \
@@ -101,7 +101,7 @@ jobs:
             echo "initializing gradle ($(which gradle))..."; \
             gradle --quiet --continue wrapper || find . -name '*/gradlew' -print || echo "whoami? $(whoami)"; \
             gradle --info -I gradle/support/fetchDependencies.gradle init || (if test -x ./gradlew; then ./gradlew --debug -I gradle/support/fetchDependencies.gradle init; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || sudo gradle --quiet --continue -I gradle/support/fetchDependencies.gradle init || ls "gradle*" || pwd; \
-            gradle prepdev eclipse buildNatives || (if test -x ./gradlew; then ./gradlew prepdev eclipse buildNatives; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || find . -name '*.gradle' -print; \
+            gradle --quiet prepdev eclipse buildNatives || (if test -x ./gradlew; then ./gradlew prepdev eclipse buildNatives; else echo "missing or invalid gradle wrapper" >&2 && exit 1; fi) || find . -name '*.gradle' -print; \
           else \
             echo "Skipping gradle initialization due to missing or unwritable gradle locations"; \
           fi; \
@@ -112,7 +112,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      if: matrix.language != 'c-cpp' # && matrix.language != 'java-kotlin'
+      if: matrix.language != 'c-cpp' && matrix.language != 'java-kotlin'
       uses: github/codeql-action/autobuild@v3
 
     - name: Manual build (C and C++)


### PR DESCRIPTION
Probably should be squashed.