### PR TITLE
Fix code scanning alert no. 18: Client-side cross-site scripting

### DIFF
--- a/GhidraDocs/GhidraClass/Intermediate/Intermediate_Ghidra_Student_Guide_withNotes.html
+++ b/GhidraDocs/GhidraClass/Intermediate/Intermediate_Ghidra_Student_Guide_withNotes.html
@@ -209,7 +209,7 @@
         this.postMsg(this.views.present, "GET_NOTES");
         this.idx = ~~cursor[0];
         this.step = ~~cursor[1];
-        $("#slideidx").innerHTML = argv[1];
+        $("#slideidx").innerHTML = DOMPurify.sanitize(argv[1]);
         this.postMsg(this.views.future, "SET_CURSOR", this.idx + "." + (this.step + 1));
         if (this.views.remote)
           this.postMsg(this.views.remote, "SET_CURSOR", argv[1]);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ghidra/security/code-scanning/18](https://github.com/cooljeanius/ghidra/security/code-scanning/18)

To fix the cross-site scripting vulnerability, we need to ensure that any user-provided data is properly sanitized before being inserted into the DOM. The best way to fix this issue is to use `DOMPurify.sanitize` to clean the user input before setting it as the inner HTML of any element.

- **General Fix:** Sanitize the user input using `DOMPurify.sanitize` before assigning it to `innerHTML`.
- **Detailed Fix:** Specifically, in the `Dz.onmessage` function, sanitize `argv[1]` before setting it to `$("#slideidx").innerHTML`.
- **Files/Regions/Lines to Change:** The changes will be made in the `GhidraDocs/GhidraClass/Intermediate/Intermediate_Ghidra_Student_Guide_withNotes.html` file, particularly around line 212.
- **Requirements:** Ensure `DOMPurify` is already imported and available in the script.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
