### PR TITLE
Fix code scanning alert no. 17: Client-side cross-site scripting

### DIFF
--- a/GhidraDocs/GhidraClass/Intermediate/HeadlessAnalyzer_withNotes.html
+++ b/GhidraDocs/GhidraClass/Intermediate/HeadlessAnalyzer_withNotes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.4/purify.min.js"></script>
 <meta charset="utf8" http-equiv="X-UA-Compatible" content="IE=Edge">
 <title>Headless Analyzer</title>
 
@@ -220,8 +220,10 @@
     if (aEvent.source === this.views.present) {
       if (argv[0] === "NOTES" && argc === 2)
         $("#notes > #content").innerHTML = this.notes = argv[1];
-      if (argv[0] === "REGISTERED" && argc === 3)
-        $("#slidecount").innerHTML = argv[2];
+      if (argv[0] === "REGISTERED" && argc === 3) {
+        var sanitizedValue = DOMPurify.sanitize(argv[2]);
+        $("#slidecount").innerHTML = sanitizedValue;
+      }
     }
   }
   


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ghidra/security/code-scanning/17](https://github.com/cooljeanius/ghidra/security/code-scanning/17)

To fix the cross-site scripting vulnerability, we need to ensure that any user-provided data is properly sanitized or encoded before being inserted into the HTML. The best way to fix this issue is to use a library that provides robust XSS protection by encoding the data before inserting it into the DOM.

In this case, we will use the `DOMPurify` library, which is a well-known library for sanitizing HTML and preventing XSS attacks. We will sanitize the `argv[2]` value before setting it as the innerHTML of the `slidecount` element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
