### PR TITLE
Fix code scanning alert no. 159: Client-side cross-site scripting

### DIFF
--- a/GhidraDocs/GhidraClass/Intermediate/HeadlessAnalyzer_withNotes.html
+++ b/GhidraDocs/GhidraClass/Intermediate/HeadlessAnalyzer_withNotes.html
@@ -219,7 +219,8 @@
     }
     if (aEvent.source === this.views.present) {
       if (argv[0] === "NOTES" && argc === 2)
-        $("#notes > #content").innerHTML = this.notes = argv[1];
+        var sanitizedNotes = DOMPurify.sanitize(argv[1]);
+        $("#notes > #content").innerHTML = this.notes = sanitizedNotes;
       if (argv[0] === "REGISTERED" && argc === 3) {
         var sanitizedValue = DOMPurify.sanitize(argv[2]);
         $("#slidecount").innerHTML = sanitizedValue;

--- a/GhidraDocs/GhidraClass/Intermediate/HeadlessAnalyzer_withNotes.html
+++ b/GhidraDocs/GhidraClass/Intermediate/HeadlessAnalyzer_withNotes.html
@@ -218,9 +218,10 @@
       }
     }
     if (aEvent.source === this.views.present) {
-      if (argv[0] === "NOTES" && argc === 2)
+      if (argv[0] === "NOTES" && argc === 2) {
         var sanitizedNotes = DOMPurify.sanitize(argv[1]);
         $("#notes > #content").innerHTML = this.notes = sanitizedNotes;
+      }
       if (argv[0] === "REGISTERED" && argc === 3) {
         var sanitizedValue = DOMPurify.sanitize(argv[2]);
         $("#slidecount").innerHTML = sanitizedValue;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ghidra/security/code-scanning/159](https://github.com/cooljeanius/ghidra/security/code-scanning/159)

To fix the cross-site scripting vulnerability, we need to sanitize the user-provided input before assigning it to `this.notes` and updating the DOM. The best way to do this is by using the `DOMPurify` library, which is already included in the project. This ensures that any potentially harmful scripts are removed from the input.

- **General Fix:** Sanitize the user input using `DOMPurify` before assigning it to `this.notes` and updating the DOM.
- **Detailed Fix:** Modify the code on line 222 to use `DOMPurify.sanitize(argv[1])` before assigning it to `this.notes` and updating the DOM.
- **Specific Changes:** Update the relevant line in the `Dz.onmessage` function to include the sanitization step.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
