### PR TITLE
Fix code scanning alert no. 15: Client-side cross-site scripting

### DIFF
--- a/GhidraDocs/GhidraClass/Intermediate/HeadlessAnalyzer_withNotes.html
+++ b/GhidraDocs/GhidraClass/Intermediate/HeadlessAnalyzer_withNotes.html
@@ -214,7 +214,8 @@
         if (this.views.remote)
           this.postMsg(this.views.remote, "SET_CURSOR", argv[1]);
       } else {
-        $("#nextslideidx").innerHTML = +argv[1] < 0 ? "END" : argv[1];
+        var sanitizedArgv1 = DOMPurify.sanitize(argv[1]);
+        $("#nextslideidx").innerHTML = +sanitizedArgv1 < 0 ? "END" : sanitizedArgv1;
       }
     }
     if (aEvent.source === this.views.present) {


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ghidra/security/code-scanning/15](https://github.com/cooljeanius/ghidra/security/code-scanning/15)

To fix the cross-site scripting vulnerability, we need to sanitize the user-provided input before inserting it into the DOM. We can use the DOMPurify library, which is already included in the script, to sanitize the `argv[1]` value before setting it as the inner HTML of the element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
