### PR TITLE
Fix code scanning alert no. 14: Client-side cross-site scripting

### DIFF
--- a/GhidraDocs/GhidraClass/Intermediate/HeadlessAnalyzer_withNotes.html
+++ b/GhidraDocs/GhidraClass/Intermediate/HeadlessAnalyzer_withNotes.html
@@ -209,7 +209,8 @@
         this.postMsg(this.views.present, "GET_NOTES");
         this.idx = ~~cursor[0];
         this.step = ~~cursor[1];
-        $("#slideidx").innerHTML = argv[1];
+        var sanitizedArgv1 = DOMPurify.sanitize(argv[1]);
+        $("#slideidx").innerHTML = sanitizedArgv1;
         this.postMsg(this.views.future, "SET_CURSOR", this.idx + "." + (this.step + 1));
         if (this.views.remote)
           this.postMsg(this.views.remote, "SET_CURSOR", argv[1]);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ghidra/security/code-scanning/14](https://github.com/cooljeanius/ghidra/security/code-scanning/14)

To fix the cross-site scripting vulnerability, we need to sanitize the user-provided input before assigning it to the `innerHTML` property. The best way to do this is to use the DOMPurify library, which is already included in the project, to sanitize `argv[1]` before it is used.

- Locate the assignment of `argv[1]` to `innerHTML` on line 212.
- Use DOMPurify to sanitize `argv[1]` before assigning it to `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
