### PR TITLE
Fix code scanning alert no. 10: Client-side cross-site scripting

### DIFF
--- a/GhidraDocs/GhidraClass/Beginner/Introduction_to_Ghidra_Student_Guide_withNotes.html
+++ b/GhidraDocs/GhidraClass/Beginner/Introduction_to_Ghidra_Student_Guide_withNotes.html
@@ -209,7 +209,7 @@
         this.postMsg(this.views.present, "GET_NOTES");
         this.idx = ~~cursor[0];
         this.step = ~~cursor[1];
-        $("#slideidx").innerHTML = argv[1];
+        $("#slideidx").innerHTML = DOMPurify.sanitize(argv[1]);
         this.postMsg(this.views.future, "SET_CURSOR", this.idx + "." + (this.step + 1));
         if (this.views.remote)
           this.postMsg(this.views.remote, "SET_CURSOR", argv[1]);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ghidra/security/code-scanning/10](https://github.com/cooljeanius/ghidra/security/code-scanning/10)

To fix the cross-site scripting vulnerability, we need to sanitize the user-provided value `argv[1]` before assigning it to the `innerHTML` property. We can use the `DOMPurify` library, which is already included in the project, to sanitize the input.

- Locate the assignment of `argv[1]` to `innerHTML` on line 212.
- Use `DOMPurify.sanitize` to clean the value of `argv[1]` before assigning it to `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
