### PR TITLE
Fix code scanning alert no. 8: Client-side cross-site scripting

### DIFF
--- a/GhidraDocs/GhidraClass/AdvancedDevelopment/GhidraAdvancedDevelopment_withNotes.html
+++ b/GhidraDocs/GhidraClass/AdvancedDevelopment/GhidraAdvancedDevelopment_withNotes.html
@@ -219,9 +219,10 @@
       }
     }
     if (aEvent.source === this.views.present) {
-      if (argv[0] === "NOTES" && argc === 2)
+      if (argv[0] === "NOTES" && argc === 2) {
         this.notes = DOMPurify.sanitize(argv[1]);
         $("#notes > #content").innerHTML = this.notes;
+      }
       if (argv[0] === "REGISTERED" && argc === 3)
         $("#slidecount").innerHTML = DOMPurify.sanitize(argv[2]);
     }

--- a/GhidraDocs/GhidraClass/AdvancedDevelopment/GhidraAdvancedDevelopment_withNotes.html
+++ b/GhidraDocs/GhidraClass/AdvancedDevelopment/GhidraAdvancedDevelopment_withNotes.html
@@ -220,7 +220,8 @@
     }
     if (aEvent.source === this.views.present) {
       if (argv[0] === "NOTES" && argc === 2)
-        $("#notes > #content").innerHTML = this.notes = argv[1];
+        this.notes = DOMPurify.sanitize(argv[1]);
+        $("#notes > #content").innerHTML = this.notes;
       if (argv[0] === "REGISTERED" && argc === 3)
         $("#slidecount").innerHTML = DOMPurify.sanitize(argv[2]);
     }


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ghidra/security/code-scanning/8](https://github.com/cooljeanius/ghidra/security/code-scanning/8)

To fix the problem, we need to sanitize the user-provided data before assigning it to `innerHTML`. The best way to do this is to use the `DOMPurify.sanitize` method, which is already included in the project. This will ensure that any potentially malicious content is removed before it is inserted into the DOM.

- Locate the assignment of `argv[1]` to `this.notes` and the subsequent assignment to `innerHTML` on line 223.
- Use `DOMPurify.sanitize` to sanitize `argv[1]` before assigning it to `this.notes` and `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
