### PR TITLE
Fix code scanning alert no. 7: Client-side cross-site scripting

### DIFF
--- a/GhidraDocs/GhidraClass/AdvancedDevelopment/GhidraAdvancedDevelopment_withNotes.html
+++ b/GhidraDocs/GhidraClass/AdvancedDevelopment/GhidraAdvancedDevelopment_withNotes.html
@@ -215,7 +215,7 @@
         if (this.views.remote)
           this.postMsg(this.views.remote, "SET_CURSOR", argv[1]);
       } else {
-        $("#nextslideidx").innerHTML = +argv[1] < 0 ? "END" : argv[1];
+        $("#nextslideidx").innerHTML = +argv[1] < 0 ? "END" : DOMPurify.sanitize(argv[1]);
       }
     }
     if (aEvent.source === this.views.present) {


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ghidra/security/code-scanning/7](https://github.com/cooljeanius/ghidra/security/code-scanning/7)

To fix the problem, we need to sanitize the user-provided data before using it in the DOM. Since the `DOMPurify` library is already included in the project, we can use it to sanitize `argv[1]` before setting it as the `innerHTML` of the element. This ensures that any potentially malicious scripts are removed from the user input.

- **General Fix:** Sanitize user input using `DOMPurify` before inserting it into the DOM.
- **Detailed Fix:** Modify the code to use `DOMPurify.sanitize` on `argv[1]` before setting it as the `innerHTML` of the element.
- **Specific Changes:** Update the relevant lines in the file `GhidraDocs/GhidraClass/AdvancedDevelopment/GhidraAdvancedDevelopment_withNotes.html`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
