### PR TITLE
Fix code scanning alert no. 6: Client-side cross-site scripting

### DIFF
--- a/GhidraDocs/GhidraClass/AdvancedDevelopment/GhidraAdvancedDevelopment_withNotes.html
+++ b/GhidraDocs/GhidraClass/AdvancedDevelopment/GhidraAdvancedDevelopment_withNotes.html
@@ -210,7 +210,7 @@
         this.postMsg(this.views.present, "GET_NOTES");
         this.idx = ~~cursor[0];
         this.step = ~~cursor[1];
-        $("#slideidx").innerHTML = argv[1];
+        $("#slideidx").innerHTML = DOMPurify.sanitize(argv[1]);
         this.postMsg(this.views.future, "SET_CURSOR", this.idx + "." + (this.step + 1));
         if (this.views.remote)
           this.postMsg(this.views.remote, "SET_CURSOR", argv[1]);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ghidra/security/code-scanning/6](https://github.com/cooljeanius/ghidra/security/code-scanning/6)

To fix the cross-site scripting vulnerability, we need to sanitize the user-provided data before inserting it into the DOM. The best way to do this is by using the DOMPurify library, which is already included in the project. We will sanitize `argv[1]` before assigning it to `innerHTML` on line 213.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
