### PR TITLE
Fix code scanning alert no. 140: Binding a socket to all network interfaces

### DIFF
--- a/Ghidra/Debug/Debugger-agent-lldb/src/main/py/src/ghidralldb/commands.py
+++ b/Ghidra/Debug/Debugger-agent-lldb/src/main/py/src/ghidralldb/commands.py
@@ -343,18 +343,18 @@ def ghidra_trace_listen(debugger, command, result, internal_dict):
 
     args = shlex.split(command)
     if len(args) == 0:
-        host, port = "0.0.0.0", 0
+        raise RuntimeError("ADDRESS must be specified as HOST:PORT or PORT")
     elif len(args) == 1:
         address = args[0]
         parts = address.split(":")
         if len(parts) == 1:
-            host, port = "0.0.0.0", parts[0]
+            raise RuntimeError("ADDRESS must be specified as HOST:PORT or PORT")
         elif len(parts) == 2:
             host, port = parts
         else:
             raise RuntimeError("ADDRESS must be PORT or HOST:PORT")
     else:
-        raise RuntimError("Usage: ghidra trace listen [ADDRESS]")
+        raise RuntimeError("Usage: ghidra trace listen [ADDRESS]")
 
     STATE.require_no_client()
     try:


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ghidra/security/code-scanning/140](https://github.com/cooljeanius/ghidra/security/code-scanning/140)

To fix the problem, we should modify the code to avoid binding to all interfaces by default. Instead, we can require the user to specify the host address explicitly. If the user does not provide a host address, we can raise an error or use a secure default address.

- Update the `ghidra_trace_listen` function to require a specific host address.
- Modify the logic to handle cases where the host address is not provided, ensuring it does not default to "0.0.0.0".
- Ensure the changes do not affect the existing functionality of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
