### PR TITLE
Fix code scanning alert no. 139: Binding a socket to all network interfaces

### DIFF
--- a/Ghidra/Debug/Debugger-agent-dbgeng/src/main/py/src/ghidrattd/commands.py
+++ b/Ghidra/Debug/Debugger-agent-dbgeng/src/main/py/src/ghidrattd/commands.py
@@ -145,7 +145,7 @@ def ghidra_trace_connect(address=None):
         raise RuntimeError("port must be numeric")
 
 
-def ghidra_trace_listen(address="0.0.0.0:0"):
+def ghidra_trace_listen(address="127.0.0.1:0"):
     """
     Listen for Ghidra to connect for tracing
 
@@ -159,7 +159,7 @@ def ghidra_trace_listen(address="0.0.0.0:0"):
     STATE.require_no_client()
     parts = address.split(":")
     if len(parts) == 1:
-        host, port = "0.0.0.0", parts[0]
+        host, port = "127.0.0.1", parts[0]
     elif len(parts) == 2:
         host, port = parts
     else:


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ghidra/security/code-scanning/139](https://github.com/cooljeanius/ghidra/security/code-scanning/139)

To fix the problem, we should change the default behavior of the `ghidra_trace_listen` function to bind to a specific interface rather than all interfaces. We can modify the default address to bind to `127.0.0.1`, which is the loopback address and only allows connections from the local machine. This change will enhance security by preventing external connections unless explicitly specified by the user.

- Change the default value of the `address` parameter in the `ghidra_trace_listen` function from `"0.0.0.0:0"` to `"127.0.0.1:0"`.
- Update the logic that handles the `address` parameter to ensure it defaults to `127.0.0.1` if no specific host is provided.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
