### PR TITLE
Fix code scanning alert no. 113: Binding a socket to all network interfaces

### DIFF
--- a/Ghidra/Debug/Debugger-agent-dbgeng/src/main/py/src/ghidradbg/commands.py
+++ b/Ghidra/Debug/Debugger-agent-dbgeng/src/main/py/src/ghidradbg/commands.py
@@ -146,21 +146,21 @@ def ghidra_trace_connect(address=None):
         raise RuntimeError("port must be numeric")
 
 
-def ghidra_trace_listen(address="0.0.0.0:0"):
+def ghidra_trace_listen(address="127.0.0.1:0"):
     """
     Listen for Ghidra to connect for tracing
 
     Takes an optional address for the host and port on which to listen. Either
     the form 'host:port' or just 'port'. If omitted, it will bind to an
-    ephemeral port on all interfaces. If only the port is given, it will bind to
-    that port on all interfaces. This command will block until the connection is
+    ephemeral port on localhost. If only the port is given, it will bind to
+    that port on localhost. This command will block until the connection is
     established.
     """
 
     STATE.require_no_client()
     parts = address.split(":")
     if len(parts) == 1:
-        host, port = "0.0.0.0", parts[0]
+        host, port = "127.0.0.1", parts[0]
     elif len(parts) == 2:
         host, port = parts
     else:


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/ghidra/security/code-scanning/113](https://github.com/cooljeanius/ghidra/security/code-scanning/113)

To fix the problem, we should modify the `ghidra_trace_listen` function to avoid binding to all interfaces by default. Instead, we can require the user to explicitly specify the host and port. If the user does not provide a host, we can bind to `127.0.0.1` (localhost) by default, which limits the exposure to the local machine.

- Change the default value of the `address` parameter to `127.0.0.1:0` to bind to localhost by default.
- Update the logic to handle cases where only the port is provided, defaulting the host to `127.0.0.1`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
